### PR TITLE
fix: compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ async-trait = "0.1.57"
 
 axon-protocol = { git = "https://github.com/axonweb3/axon", package = "axon-protocol", tag = "v0.1.0-alpha.1" }
 
-ckb-crypto = { version = "0.105", features = ["secp"] }
-ckb-fixed-hash-core = "0.105"
-ckb-hash = "0.105"
-ckb-jsonrpc-types = "=0.105"
+ckb-crypto = { version = "0.106", features = ["secp"] }
+ckb-fixed-hash-core = "0.106"
+ckb-hash = "0.106"
+ckb-jsonrpc-types = "0.106"
 ckb-sdk = "2.2"
-ckb-types = "0.105"
+ckb-types = "0.106"
 
 blake2b-rs = "0.2"
 ophelia = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ ckb-crypto = { version = "0.106", features = ["secp"] }
 ckb-fixed-hash-core = "0.106"
 ckb-hash = "0.106"
 ckb-jsonrpc-types = "0.106"
-ckb-sdk = "2.2"
+ckb-sdk = "~2.4"
 ckb-types = "0.106"
 
 blake2b-rs = "0.2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Fix compilation errors.

```
error[E0308]: mismatched types
  --> src/crosschain_tx/ckb_context.rs:94:66
   |
94 |         let cell_dep_resolver = OffchainCellDepResolver { items: cell_deps };
   |                                                                  ^^^^^^^^^ expected struct `ckb_types::generated::blockchain::CellDep`, found struct `ckb_types::packed::CellDep`
```

#### CI Switch

ci-runs-only: [Cargo Clippy, Code Format, Unit Tests]
